### PR TITLE
Add bash options to cause scripts to fail under various conditions.

### DIFF
--- a/bam_to_cram
+++ b/bam_to_cram
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o pipefail
+set -o errexit
+set -o nounset
+
 #arg1 = reference fasta
 #arg2 = bam file
 #arg3 = output cram

--- a/bsvcf2bed
+++ b/bsvcf2bed
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o pipefail
+set -o errexit
+set -o nounset
+
 #arg1 = /path/to/input/biscuit_pileup.vcf 
 #arg2 = /path/to/output/cpgs.bed.gz
 #arg3 = /path/to/output/cpgs.bedgraph

--- a/sambamba_merge
+++ b/sambamba_merge
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o pipefail
+set -o errexit
+set -o nounset
+
 # arguments are:
 # 1    - number of cores
 # 2    - outfile


### PR DESCRIPTION
We ran into some trouble with other pipelines where omitting these was covering up bugs.

(I haven't tested these changes here, so hopefully `bsvcf2bed` isn't relying on allowing broken pipes!)