### PR TITLE
adding new pileup to vcf script that merges CpG strands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y && apt-get install -y \
     git \
     libncurses5-dev \
     libcurl4-openssl-dev \
+    liblist-moreutils-perl \
     libtbb2 \
     libtbb-dev \
     nodejs \
@@ -124,6 +125,7 @@ RUN wget https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1
     
 #wrapper script for converting vcf2bed
 ADD bsvcf2bed /usr/bin/
+ADD biscuitVcfToBed.pl /usr/bin/
 ADD bam_to_cram /usr/bin/
 
 ######

--- a/biscuitVcfToBed.pl
+++ b/biscuitVcfToBed.pl
@@ -50,6 +50,7 @@ while(my $line = <INVCF>){
             $prev{"BT"} = $vals[$bt_ind];
         } else {
             #not a C or G - this should never happen
+            die("ERROR: CpG context reported, but ref base isn't a C or G:\n$line\n");
             next;
         }
     } else {
@@ -77,7 +78,7 @@ while(my $line = <INVCF>){
             }
         } else {
             #not a C or G - this should never happen
-            next;
+            die("ERROR: CpG context reported, but ref base isn't a C or G:\n$line\n");
         }
     }
 }

--- a/biscuitVcfToBed.pl
+++ b/biscuitVcfToBed.pl
@@ -51,7 +51,6 @@ while(my $line = <INVCF>){
         } else {
             #not a C or G - this should never happen
             die("ERROR: CpG context reported, but ref base isn't a C or G:\n$line\n");
-            next;
         }
     } else {
         #prev has data, this is a C, print prev, store this

--- a/biscuitVcfToBed.pl
+++ b/biscuitVcfToBed.pl
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use IO::File;
+use List::MoreUtils qw(first_index);
+
+my %prev;
+
+my $mindepth=2;
+
+#handle gzipped or not vcfs
+my $file = $ARGV[0];
+if ($file =~ /.gz$/) {
+    open(INVCF, "gunzip -c $file |") || die "can’t open pipe to $file";
+} else {
+    open(INVCF, $file) || die "can’t open $file";
+}
+
+while(my $line = <INVCF>){
+    next if $line =~ /^#/;
+    chomp($line);
+    my @F = split("\t",$line);
+    next if $F[4] ne "."; #skip SNPs
+    next unless $F[7] =~ /CX=CG/; #we only care about CpGs
+
+    #get the CV and BT format field locations
+    my @fmt = split(":",$F[8]);
+    my $cv_ind = first_index { $_ eq 'CV' } @fmt;
+    my $bt_ind = first_index { $_ eq 'BT' } @fmt;
+
+    if ($bt_ind == -1 || $cv_ind == -1){
+        print STDERR "WARNING: expected CV and/or BT format fields not found:\n";
+        print STDERR $line . "\n";
+        next;
+    }
+    my @vals = split(":",$F[9]);
+
+    #cases
+    if(!(defined($prev{"chr"}))){
+        #prev is empty, this is a G (just print)
+        if($F[3] eq "G"){
+            print join("\t", ($F[0], $F[1]-1, $F[1], $vals[$cv_ind], $vals[$bt_ind])) . "\n"  if $vals[$cv_ind] >= $mindepth;
+        } elsif($F[3] eq "C"){
+            #prev is empty, this is a C (store)
+            $prev{"chr"} = $F[0];
+            $prev{"pos"} = $F[1];
+            $prev{"base"} = $F[3];
+            $prev{"CV"} = $vals[$cv_ind];
+            $prev{"BT"} = $vals[$bt_ind];
+        } else {
+            #not a C or G - this should never happen
+            next;
+        }
+    } else {
+        #prev has data, this is a C, print prev, store this
+        if($F[3] eq "C"){
+            print join("\t", ($prev{"chr"}, $prev{"pos"}-1, $prev{"pos"}, $prev{"CV"}, $prev{"BT"})) . "\n" if $prev{"CV"} >= $mindepth;
+            $prev{"chr"} = $F[0];
+            $prev{"pos"} = $F[1];
+            $prev{"base"} = $F[3];
+            $prev{"CV"} = $vals[$cv_ind];
+            $prev{"BT"} = $vals[$bt_ind];
+
+        } elsif($F[3] eq "G"){
+
+            #prev has data, this is the adjacent G, (combine, print, blank prev)
+            if($F[0] eq $prev{"chr"} && $F[1] == $prev{"pos"}+1){
+                my $bt = sprintf("%.2f", (($prev{"CV"}*$prev{"BT"}) + ($vals[$cv_ind]*$vals[$bt_ind]))/($prev{"CV"}+$vals[$cv_ind]));
+                print join("\t", ($prev{"chr"}, $prev{"pos"}-1, $prev{"pos"}, $prev{"CV"}+$vals[$cv_ind],$bt)) . "\n" if ($prev{"CV"}+$vals[$cv_ind]) >= $mindepth;
+                undef %prev;
+            } else {
+                #prev has data, this is a non-adjacent G (print prev, print this, blank prev)
+                print join("\t", ($prev{"chr"}, $prev{"pos"}-1, $prev{"pos"}, $prev{"CV"}, $prev{"BT"})) . "\n" if $prev{"CV"} >= $mindepth;
+                print join("\t", ($F[0], $F[1]-1, $F[1], $vals[$cv_ind], $vals[$bt_ind])) . "\n" if $vals[$cv_ind] >= $mindepth;
+                undef %prev;
+            }
+        } else {
+            #not a C or G - this should never happen
+            next;
+        }
+    }
+}
+
+#close out by printing last contents of prev, if they exist
+if(defined($prev{"chr"})){
+    print join("\t", ($prev{"chr"}, $prev{"pos"}-1, $prev{"pos"}, $prev{"CV"}, $prev{"BT"})) . "\n" if $prev{"CV"} >= $mindepth;
+}
+close(INVCF);
+
+# Example vcf line
+# 0       chr2
+# 1       252430
+# 2       .
+# 3       G
+# 4       .
+# 5       15
+# 6       PASS
+# 7       NS=1;CX=CHH;N5=CCCTA
+# 8       GT:GL1:GQ:DP:SP:CV:BT
+# 9       0/0:-1,-5,-25:15:5:G3R2:2:0.00

--- a/bsvcf2bed
+++ b/bsvcf2bed
@@ -14,4 +14,4 @@ if [[ "$#" -lt 3 ]]; then
     exit 1
 fi
 
-/usr/bin/biscuit vcf2bed -k 2 -t cg "$1" | tee >(/bin/gzip >"$2") | cut -f 1-4 | sort -k1,1 -k2,2n -S 12G | /usr/bin/perl -ne 'print $_ if $_ =~ /^(chr)?[1-9]?[0-9|X|Y]\s/' >"$3"
+perl /usr/bin/biscuitVcfToBed.pl "$1" |  tee >(/bin/gzip >"$2") | cut -f 1-4 | sort -k1,1 -k2,2n -S 12G | /usr/bin/perl -ne 'print $_ if $_ =~ /^(chr)?[1-9]?[0-9|X|Y]\s/' >"$3"


### PR DESCRIPTION
The biscuit utility `vcf2bed` has some unwanted behavior, in that it doesn't collapse the strands at each CpG (see https://github.com/zwdzwd/biscuit/issues/29).  That's not necessarily incorrect, but it's not what we want. 

To replace it, I wrote a simple little perl script that parses the bisulfite VCF, grabs adjacent CpG positions, and merges them into a single count and beta value per CpG.  That's been added, tested, and swapped into the wrapper script here.  Once merged, I'll tag this as v1.3 of the image and update processing profiles accordingly.  